### PR TITLE
Add "version" header and automated redirection

### DIFF
--- a/cmd/measure-upload/main.go
+++ b/cmd/measure-upload/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/go-pg/pg"
 	"github.com/go-pg/pg/orm"
@@ -76,6 +77,7 @@ func main() {
 	}
 
 	// Endpoints' routing.
+	e.Pre(apiVersion)
 	e.POST("/v0/measurements", measurementsHandler.Post)
 
 	// Start the Echo server.
@@ -92,4 +94,19 @@ func createSchema(db internal.Database) error {
 	}
 
 	return nil
+}
+
+// apiVersion is a middleware function that reads the "version" header from the
+// HTTP request and routes it to the correct URL.
+func apiVersion(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		req := c.Request()
+		version := req.Header.Get("version")
+
+		if version != "" {
+			req.URL.Path = fmt.Sprintf("/%s%s", version, req.URL.Path)
+		}
+
+		return next(c)
+	}
 }

--- a/cmd/measure-upload/main_test.go
+++ b/cmd/measure-upload/main_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"errors"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/go-pg/pg/orm"
+	"github.com/labstack/echo"
 )
 
 type mockDB struct {
@@ -37,4 +39,37 @@ func Test_createSchema(t *testing.T) {
 	if err == nil {
 		t.Errorf("createSchema() expected error, got nil")
 	}
+}
+
+func Test_apiVersion(t *testing.T) {
+	e := echo.New()
+	e.Pre(apiVersion)
+
+	t.Run("redirect-to-versioned-path", func(t *testing.T) {
+		req := httptest.NewRequest(echo.GET, "/endpoint", nil)
+		rec := httptest.NewRecorder()
+
+		req.Header.Set("version", "v0")
+		req.URL.Path = "/endpoint"
+
+		e.ServeHTTP(rec, req)
+
+		if req.URL.Path != "/v0/endpoint" {
+			t.Errorf("apiVersion() returned wrong path %s", req.URL.Path)
+		}
+	})
+
+	t.Run("no-redirect-if-version-unspecified", func(t *testing.T) {
+		req := httptest.NewRequest(echo.GET, "/endpoint", nil)
+		rec := httptest.NewRecorder()
+
+		req.URL.Path = "/endpoint"
+
+		e.ServeHTTP(rec, req)
+
+		if req.URL.Path != "/endpoint" {
+			t.Errorf("apiVersion() returned wrong path %s", req.URL.Path)
+		}
+	})
+
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-pg/pg v8.0.6+incompatible
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator v9.31.0+incompatible
-	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,7 @@ github.com/go-playground/validator v9.31.0+incompatible/go.mod h1:yrEkQXlcI+Pugk
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -62,7 +63,6 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
-github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
@@ -72,9 +72,8 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
+github.com/golang/protobuf v1.4.1 h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
-github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
-github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -324,7 +323,6 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=


### PR DESCRIPTION
This PR adds a mechanism to allow clients to specify the API version via a `version` header. This is implemented via a middleware function that rewrites the URL by prepending the content of `version` -- e.g. `/measurements` with `version: v0` becomes `/v0/measurements`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/measure-upload-service/3)
<!-- Reviewable:end -->
