### PR TITLE
Extend Measurement struct with ClientInfo and ServerInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,17 @@ Example:
   "Download": 100,
   "Upload": 50,
   "Latency": 20,
+  "ClientInfo": {
+    [the ClientInfo object]
+  },
+  "ServerInfo": {
+    [the ServerInfo object]
+  },
   "Results": {
     [the NDT results object]
   }
 }
 ```
 
-The NDT Results object is defined [here](internal/model/measurement.go).
+The ClientInfo, ServerInfo and Results objects are defined
+[here](internal/model/measurement.go).

--- a/internal/model/measurement.go
+++ b/internal/model/measurement.go
@@ -14,11 +14,47 @@ type Measurement struct {
 	// Notes is a free-form string containing browser-specific notes.
 	Notes string
 
+	// ClientInfo is a JSONB containing information about the client.
+	ClientInfo ClientInfo
+
+	// Server is a JSONB containing information about the server.
+	ServerInfo ServerInfo
+
 	Download float64 `pg:",use_zero" validate:"required"`
 	Upload   float64 `pg:",use_zero" validate:"required"`
 	Latency  int     `pg:",use_zero" validate:"required"`
 
+	// Results is a JSONB containing extra debug information about the
+	// measurement.
 	Results Results
+}
+
+// ClientInfo is a data structure for storing client-related metadata.
+type ClientInfo struct {
+	ASN       string
+	City      string
+	Country   string
+	Hostname  string
+	IP        string
+	Latitude  float32
+	Longitude float32
+	ISP       string
+	Postal    string
+	Region    string
+	Timezone  string
+}
+
+// ServerInfo is a data structure for storing server-related metadata.
+type ServerInfo struct {
+	FQDN    string
+	IPv4    string
+	IPv6    string
+	City    string
+	Country string
+	Label   string
+	Metro   string
+	Site    string
+	URL     string
 }
 
 // Results represents the NDT variables sent by the server at the end of


### PR DESCRIPTION
This PR adds the `ClientInfo` and `ServerInfo` JSONB fields to the `measurement` table's schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/measure-saver/9)
<!-- Reviewable:end -->
