### PR TITLE
Add UUID and Timestamp fields

### DIFF
--- a/internal/model/measurement.go
+++ b/internal/model/measurement.go
@@ -1,9 +1,17 @@
 package model
 
+import "time"
+
 // Measurement is the data format exchanged between the uploader and this
 // service.
 type Measurement struct {
 	ID int64 `pg:",pk"`
+
+	// Timestamp is the timestamp of this Measurement.
+	Timestamp time.Time
+
+	// UUID is the server-generated UUID for the S2C test.
+	UUID string `pg:",unique"`
 
 	// BrowserID is a unique identifier for this Measurement's uploader.
 	BrowserID string `sql:",notnull" validate:"required"`


### PR DESCRIPTION
This PR adds new fields, `uuid` and `timestamp`, to the `measurement` table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/measure-saver/10)
<!-- Reviewable:end -->
