### PR TITLE
Use ENTRYPOINT instead of CMD.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ FROM alpine:3.12.0
 
 COPY --from=build /measure-saver/measure-saver /measure-saver
 # Command to run the executable
-CMD ["/measure-saver"]
+ENTRYPOINT ["/measure-saver"]


### PR DESCRIPTION

This allows the user to easily specify additional command-line flags when
running with `docker run`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/measure-saver/15)
<!-- Reviewable:end -->
