### PR TITLE
Add a more complete example to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ A more complete example of how to run measure-saver with a remote PostgreSQL dat
 
 ```bash
 docker run --network=host measurementlab/measure-saver:latest \
-  -db.addr "myhost:5432"
-  -db.name "database-name"
-  -db.user "user"
-  -db.pass "password"
-  -keys.file "authorized_api_keys.txt"
-  -tls.cert "certs/cert.pem"
+  -db.addr "myhost:5432" \
+  -db.name "database-name" \
+  -db.user "user" \
+  -db.pass "password" \
+  -keys.file "authorized_api_keys.txt" \
+  -tls.cert "certs/cert.pem" \
   -tls.key "certs/key.pem"
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ automatically created for you:
 docker run --network=host measurementlab/measure-saver:latest
 ```
 
+A more complete example of how to run measure-saver with a remote PostgreSQL database, an authorized keys file and a TLS certificate:
+
+```bash
+docker run --network=host measurementlab/measure-saver:latest \
+  -db.addr "myhost:5432"
+  -db.name "database-name"
+  -db.user "user"
+  -db.pass "password"
+  -keys.file "authorized_api_keys.txt"
+  -tls.cert "certs/cert.pem"
+  -tls.key "certs/key.pem"
+```
+
 For a complete and up-to-date list of the available flags, please refer to the
 output of `-help`.
 


### PR DESCRIPTION

This change adds a complete example of how to run measure-saver with a remote
database, a keys file and a TLS certificate, covering all the currently
implemented command-line flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/measure-saver/16)
<!-- Reviewable:end -->
