### PR TITLE
DOC: updated Postgres instructions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For the purpose of testing this application, you can just run it in a Docker
 container:
 
 ```bash
-docker run --name postgres-dev -d postgres:12.3-alpine
+docker run --name postgres-dev -e POSTGRES_PASSWORD=secret -d postgres:12.3-alpine
 ```
 
 Then, spawn a psql instance into the running container:


### PR DESCRIPTION
Hi there 👋

I'm following the installation instructions, and running the docker postgres container fails silently if you don't specify a password as you launch the container. The proposed change addresses that by passing the default password on the command line, which matches the default configuration of the `measure-saver` container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/measure-saver/17)
<!-- Reviewable:end -->
